### PR TITLE
Handle other events

### DIFF
--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -58,6 +58,8 @@ pub enum HydraMessagePayload {
     HeadIsInitializing { raw_json: String },
     #[serde(deserialize_with = "deserialize_raw_json_committed")]
     Committed { raw_json: String },
+    #[serde(deserialize_with = "deserialize_raw_json_head_is_open")]
+    HeadIsOpen { raw_json: String },
 
     #[serde(other)]
     Other,
@@ -118,6 +120,13 @@ where
     D: Deserializer<'de>,
 {
     deserialize_raw_json(deserializer, Value::String("Committed".to_string()))
+}
+
+fn deserialize_raw_json_head_is_open<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_raw_json(deserializer, Value::String("HeadIsOpen".to_string()))
 }
 
 fn deserialize_raw_json<'de, D>(deserializer: D, evt: Value) -> Result<String, D::Error>

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -64,6 +64,8 @@ pub enum HydraMessagePayload {
     HeadIsClosed { raw_json: String },
     #[serde(deserialize_with = "deserialize_raw_json_ready_to_fanout")]
     ReadyToFanout { raw_json: String },
+    #[serde(deserialize_with = "deserialize_raw_json_head_is_finalized")]
+    HeadIsFinalized { raw_json: String },
 
     #[serde(other)]
     Other,
@@ -145,6 +147,13 @@ where
     D: Deserializer<'de>,
 {
     deserialize_raw_json(deserializer, Value::String("ReadyToFanout".to_string()))
+}
+
+fn deserialize_raw_json_head_is_finalized<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_raw_json(deserializer, Value::String("HeadIsFinalized".to_string()))
 }
 
 fn deserialize_raw_json<'de, D>(deserializer: D, evt: Value) -> Result<String, D::Error>

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -48,6 +48,7 @@ impl<'de> Deserialize<'de> for HydraMessage {
 pub enum HydraMessagePayload {
     #[serde(deserialize_with = "deserialize_tx_valid")]
     TxValid { tx: Vec<u8>, head_id: Vec<u8> },
+
     #[serde(deserialize_with = "deserialize_raw_json_peer_connected")]
     PeerConnected { raw_json: String },
     #[serde(deserialize_with = "deserialize_raw_json_idle")]
@@ -55,6 +56,9 @@ pub enum HydraMessagePayload {
     Idle { raw_json: String },
     #[serde(deserialize_with = "deserialize_raw_json_head_is_initializing")]
     HeadIsInitializing { raw_json: String },
+    #[serde(deserialize_with = "deserialize_raw_json_committed")]
+    Committed { raw_json: String },
+
     #[serde(other)]
     Other,
 }
@@ -107,6 +111,13 @@ where
         deserializer,
         Value::String("HeadIsInitializing".to_string()),
     )
+}
+
+fn deserialize_raw_json_committed<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_raw_json(deserializer, Value::String("Committed".to_string()))
 }
 
 fn deserialize_raw_json<'de, D>(deserializer: D, evt: Value) -> Result<String, D::Error>

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -62,6 +62,8 @@ pub enum HydraMessagePayload {
     HeadIsOpen { raw_json: String },
     #[serde(deserialize_with = "deserialize_raw_json_head_is_closed")]
     HeadIsClosed { raw_json: String },
+    #[serde(deserialize_with = "deserialize_raw_json_ready_to_fanout")]
+    ReadyToFanout { raw_json: String },
 
     #[serde(other)]
     Other,
@@ -136,6 +138,13 @@ where
     D: Deserializer<'de>,
 {
     deserialize_raw_json(deserializer, Value::String("HeadIsClosed".to_string()))
+}
+
+fn deserialize_raw_json_ready_to_fanout<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_raw_json(deserializer, Value::String("ReadyToFanout".to_string()))
 }
 
 fn deserialize_raw_json<'de, D>(deserializer: D, evt: Value) -> Result<String, D::Error>

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -60,6 +60,8 @@ pub enum HydraMessagePayload {
     Committed { raw_json: String },
     #[serde(deserialize_with = "deserialize_raw_json_head_is_open")]
     HeadIsOpen { raw_json: String },
+    #[serde(deserialize_with = "deserialize_raw_json_head_is_closed")]
+    HeadIsClosed { raw_json: String },
 
     #[serde(other)]
     Other,
@@ -127,6 +129,13 @@ where
     D: Deserializer<'de>,
 {
     deserialize_raw_json(deserializer, Value::String("HeadIsOpen".to_string()))
+}
+
+fn deserialize_raw_json_head_is_closed<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_raw_json(deserializer, Value::String("HeadIsClosed".to_string()))
 }
 
 fn deserialize_raw_json<'de, D>(deserializer: D, evt: Value) -> Result<String, D::Error>

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -53,6 +53,8 @@ pub enum HydraMessagePayload {
     #[serde(deserialize_with = "deserialize_raw_json_idle")]
     #[serde(alias = "Greetings")]
     Idle { raw_json: String },
+    #[serde(deserialize_with = "deserialize_raw_json_head_is_initializing")]
+    HeadIsInitializing { raw_json: String },
     #[serde(other)]
     Other,
 }
@@ -95,6 +97,16 @@ where
     D: Deserializer<'de>,
 {
     deserialize_raw_json(deserializer, Value::String("Idle".to_string()))
+}
+
+fn deserialize_raw_json_head_is_initializing<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_raw_json(
+        deserializer,
+        Value::String("HeadIsInitializing".to_string()),
+    )
 }
 
 fn deserialize_raw_json<'de, D>(deserializer: D, evt: Value) -> Result<String, D::Error>

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -58,6 +58,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::HeadIsFinalized { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -369,6 +374,76 @@ fn ready_to_fanout_evt() -> TestResult {
    "tag": "ReadyToFanout",
    "timestamp": "2024-10-08T13:07:37.807683329Z"
  }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn head_is_finalized_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 11,
+        payload: HydraMessagePayload::HeadIsFinalized {
+            raw_json: String::from(
+                "{\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\",\"utxo\":{\"633777d68a85fe989f88aa839aa84743f64d68a931192c41f4df8ed0f16e03d1#0\":{\"address\":\"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":2000000}},\"633777d68a85fe989f88aa839aa84743f64d68a931192c41f4df8ed0f16e03d1#1\":{\"address\":\"addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":23000000}},\"7b27f432e04984dc21ee61e8b1539775cd72cc8669f72cf39aebf6d87e35c697#0\":{\"address\":\"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":50000000}},\"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0\":{\"address\":\"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":100000000}}},\"timestamp\":\"2024-10-08T13:07:40.815046135Z\",\"tag\":\"HeadIsFinalized\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"",
+        "\"utxo\":{\"633777d68a85fe989f88aa839aa84743f64d68a931192c41f4df8ed0f16e03d1#0\":{\"address\":\"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":2000000}},\"633777d68a85fe989f88aa839aa84743f64d68a931192c41f4df8ed0f16e03d1#1\":{\"address\":\"addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":23000000}},\"7b27f432e04984dc21ee61e8b1539775cd72cc8669f72cf39aebf6d87e35c697#0\":{\"address\":\"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":50000000}},\"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0\":{\"address\":\"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":100000000}}}",
+        "\"timestamp\":\"2024-10-08T13:07:40.815046135Z\"",
+        "\"tag\":\"HeadIsFinalized\"",
+    ];
+
+    let raw_str = r#"
+ {
+   "headId": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab",
+   "seq": 11,
+   "tag": "HeadIsFinalized",
+   "timestamp": "2024-10-08T13:07:40.815046135Z",
+   "utxo": {
+     "633777d68a85fe989f88aa839aa84743f64d68a931192c41f4df8ed0f16e03d1#0": {
+       "address": "addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 2000000
+       }
+     },
+     "633777d68a85fe989f88aa839aa84743f64d68a931192c41f4df8ed0f16e03d1#1": {
+       "address": "addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 23000000
+       }
+     },
+     "7b27f432e04984dc21ee61e8b1539775cd72cc8669f72cf39aebf6d87e35c697#0": {
+       "address": "addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 50000000
+       }
+     },
+     "c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0": {
+       "address": "addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 100000000
+       }
+     }
+   }
+}
 "#;
     test_other_event_deserialization(evt, &json_parts, &raw_str)
 }

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -33,6 +33,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::HeadIsInitializing { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -142,6 +147,45 @@ fn idle_evt() -> TestResult {
    "seq": 2,
    "tag": "Greetings",
    "timestamp": "2024-10-08T13:04:56.445761285Z"
+ }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn head_is_initializing_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 2,
+        payload: HydraMessagePayload::HeadIsInitializing {
+            raw_json: String::from(
+                "{\"timestamp\":\"2024-10-08T13:05:47.330461177Z\",\"parties\":[{\"vkey\":\"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb\"},{\"vkey\":\"f68e5624f885d521d2f43c3959a0de70496d5464bd3171aba8248f50d5d72b41\"},{\"vkey\":\"7abcda7de6d883e7570118c1ccc8ee2e911f2e628a41ab0685ffee15f39bba96\"}],\"tag\":\"HeadIsInitializing\",\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"timestamp\":\"2024-10-08T13:05:47.330461177Z\"",
+        "\"parties\":[{\"vkey\":\"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb\"},{\"vkey\":\"f68e5624f885d521d2f43c3959a0de70496d5464bd3171aba8248f50d5d72b41\"},{\"vkey\":\"7abcda7de6d883e7570118c1ccc8ee2e911f2e628a41ab0685ffee15f39bba96\"}]",
+        "\"tag\":\"HeadIsInitializing\"",
+        "\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"",
+    ];
+
+    let raw_str = r#"
+ {
+   "headId": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab",
+   "parties": [
+     {
+       "vkey": "b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb"
+     },
+     {
+       "vkey": "f68e5624f885d521d2f43c3959a0de70496d5464bd3171aba8248f50d5d72b41"
+     },
+     {
+       "vkey": "7abcda7de6d883e7570118c1ccc8ee2e911f2e628a41ab0685ffee15f39bba96"
+     }
+   ],
+   "seq": 2,
+   "tag": "HeadIsInitializing",
+   "timestamp": "2024-10-08T13:05:47.330461177Z"
  }
 "#;
     test_other_event_deserialization(evt, &json_parts, &raw_str)

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -28,6 +28,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::Idle { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -105,6 +110,38 @@ fn peer_connected_evt() -> TestResult {
    "seq": 0,
    "tag": "PeerConnected",
    "timestamp": "2024-10-08T13:01:20.556003751Z"
+ }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn idle_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 2,
+        payload: HydraMessagePayload::Idle {
+            raw_json: String::from(
+                "{\"hydraNodeVersion\":\"0.19.0-1ffe7c6b505e3f38b5546ae5e5b97de26bc70425\",\"me\":{\"vkey\":\"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb\"},\"timestamp\":\"2024-10-08T13:04:56.445761285Z\",\"tag\":\"Idle\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"tag\":\"Idle\"",
+        "\"hydraNodeVersion\":\"0.19.0-1ffe7c6b505e3f38b5546ae5e5b97de26bc70425\"",
+        "\"me\":{\"vkey\":\"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb\"",
+        "\"timestamp\":\"2024-10-08T13:04:56.445761285Z\"",
+    ];
+
+    let raw_str = r#"
+ {
+   "headStatus": "Idle",
+   "hydraNodeVersion": "0.19.0-1ffe7c6b505e3f38b5546ae5e5b97de26bc70425",
+   "me": {
+     "vkey": "b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb"
+   },
+   "seq": 2,
+   "tag": "Greetings",
+   "timestamp": "2024-10-08T13:04:56.445761285Z"
  }
 "#;
     test_other_event_deserialization(evt, &json_parts, &raw_str)

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -53,6 +53,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::ReadyToFanout { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -336,6 +341,33 @@ fn head_is_closed_evt() -> TestResult {
    "snapshotNumber": 1,
    "tag": "HeadIsClosed",
    "timestamp": "2024-10-08T13:07:31.814065753Z"
+ }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn ready_to_fanout_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 10,
+        payload: HydraMessagePayload::ReadyToFanout {
+            raw_json: String::from(
+                "{\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\",\"tag\":\"ReadyToFanout\",\"timestamp\":\"2024-10-08T13:07:37.807683329Z\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"",
+        "\"tag\":\"ReadyToFanout\"",
+        "\"timestamp\":\"2024-10-08T13:07:37.807683329Z\"",
+    ];
+
+    let raw_str = r#"
+ {
+   "headId": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab",
+   "seq": 10,
+   "tag": "ReadyToFanout",
+   "timestamp": "2024-10-08T13:07:37.807683329Z"
  }
 "#;
     test_other_event_deserialization(evt, &json_parts, &raw_str)

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -43,6 +43,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::HeadIsOpen { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -232,6 +237,66 @@ fn committed_evt() -> TestResult {
        "referenceScript": null,
        "value": {
          "lovelace": 100000000
+       }
+     }
+   }
+ }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn head_is_open_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 6,
+        payload: HydraMessagePayload::HeadIsOpen {
+            raw_json: String::from(
+                "{\"tag\":\"HeadIsOpen\",\"utxo\":{\"7b27f432e04984dc21ee61e8b1539775cd72cc8669f72cf39aebf6d87e35c697#0\":{\"address\":\"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":50000000}},\"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0\":{\"address\":\"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":100000000}},\"f0a39560ea80ccc68e8dffb6a4a077c8927811f06c5d9058d0fa2d1a8d047d20#0\":{\"address\":\"addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":25000000}}},\"timestamp\":\"2024-10-08T13:06:18.687120539Z\",\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"tag\":\"HeadIsOpen\"",
+        "\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"",
+        "\"timestamp\":\"2024-10-08T13:06:18.687120539Z\"",
+        "\"utxo\":{\"7b27f432e04984dc21ee61e8b1539775cd72cc8669f72cf39aebf6d87e35c697#0\":{\"address\":\"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":50000000}},\"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0\":{\"address\":\"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":100000000}},\"f0a39560ea80ccc68e8dffb6a4a077c8927811f06c5d9058d0fa2d1a8d047d20#0\":{\"address\":\"addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":25000000}}}",
+    ];
+
+    let raw_str = r#"
+ {
+   "headId": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab",
+   "seq": 6,
+   "tag": "HeadIsOpen",
+   "timestamp": "2024-10-08T13:06:18.687120539Z",
+   "utxo": {
+     "7b27f432e04984dc21ee61e8b1539775cd72cc8669f72cf39aebf6d87e35c697#0": {
+       "address": "addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 50000000
+       }
+     },
+     "c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0": {
+       "address": "addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 100000000
+       }
+     },
+     "f0a39560ea80ccc68e8dffb6a4a077c8927811f06c5d9058d0fa2d1a8d047d20#0": {
+       "address": "addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 25000000
        }
      }
    }

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -38,6 +38,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::Committed { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -186,6 +191,50 @@ fn head_is_initializing_evt() -> TestResult {
    "seq": 2,
    "tag": "HeadIsInitializing",
    "timestamp": "2024-10-08T13:05:47.330461177Z"
+ }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn committed_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 3,
+        payload: HydraMessagePayload::Committed {
+            raw_json: String::from(
+                "{\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\",\"timestamp\":\"2024-10-08T13:05:56.918549005Z\",\"utxo\":{\"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0\":{\"address\":\"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":100000000}}},\"party\":{\"vkey\":\"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb\"},\"tag\":\"Committed\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"",
+        "\"timestamp\":\"2024-10-08T13:05:56.918549005Z\"",
+        "\"utxo\":{\"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0\":{\"address\":\"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z\",\"datum\":null,\"datumhash\":null,\"inlineDatum\":null,\"referenceScript\":null,\"value\":{\"lovelace\":100000000}}}",
+        "\"party\":{\"vkey\":\"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb\"}",
+        "\"tag\":\"Committed\"",
+    ];
+
+    let raw_str = r#"
+ {
+   "headId": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab",
+   "party": {
+     "vkey": "b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb"
+   },
+   "seq": 3,
+   "tag": "Committed",
+   "timestamp": "2024-10-08T13:05:56.918549005Z",
+   "utxo": {
+     "c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0": {
+       "address": "addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z",
+       "datum": null,
+       "datumhash": null,
+       "inlineDatum": null,
+       "referenceScript": null,
+       "value": {
+         "lovelace": 100000000
+       }
+     }
+   }
  }
 "#;
     test_other_event_deserialization(evt, &json_parts, &raw_str)

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -48,6 +48,11 @@ fn test_other_event_deserialization(
                 assert_eq!(raw_json.contains(thestr), true);
             }
         }
+        HydraMessagePayload::HeadIsClosed { raw_json } => {
+            for thestr in expected_str {
+                assert_eq!(raw_json.contains(thestr), true);
+            }
+        }
         _ => {
             panic!("Only other events tested here");
         }
@@ -300,6 +305,37 @@ fn head_is_open_evt() -> TestResult {
        }
      }
    }
+ }
+"#;
+    test_other_event_deserialization(evt, &json_parts, &raw_str)
+}
+
+#[test]
+fn head_is_closed_evt() -> TestResult {
+    let evt = HydraMessage {
+        seq: 9,
+        payload: HydraMessagePayload::HeadIsClosed {
+            raw_json: String::from(
+                "{\"snapshotNumber\":1,\"tag\":\"HeadIsClosed\",\"contestationDeadline\":\"2024-10-08T13:07:37.7Z\",\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\",\"timestamp\":\"2024-10-08T13:07:31.814065753Z\"}",
+            ),
+        },
+    };
+    let json_parts = vec![
+        "\"snapshotNumber\":1",
+        "\"tag\":\"HeadIsClosed\"",
+        "\"contestationDeadline\":\"2024-10-08T13:07:37.7Z\"",
+        "\"headId\":\"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab\"",
+        "\"timestamp\":\"2024-10-08T13:07:31.814065753Z\"",
+    ];
+
+    let raw_str = r#"
+ {
+   "contestationDeadline": "2024-10-08T13:07:37.7Z",
+   "headId": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab",
+   "seq": 9,
+   "snapshotNumber": 1,
+   "tag": "HeadIsClosed",
+   "timestamp": "2024-10-08T13:07:31.814065753Z"
  }
 "#;
     test_other_event_deserialization(evt, &json_parts, &raw_str)


### PR DESCRIPTION
I tried to use `RawValue` but failed to obtain satisfactory results.

Also in every "other event" I have added tag (as it was removed), removed "seq" field as it is duplicated , also "cleaned" Greetings event as is outlier and I do not think it complies with other events.

I also left alone 
```
"tag":"SnapshotConfirmed"
``` 

as if I understand well it is going to be addressed in separate PR.

All events tested. Testing does not use assert_eq but String's contain as the resultant string field order is not deterministic.