### PR TITLE
Add basic intersect logic to hydra source

### DIFF
--- a/examples/hydra/daemon.toml
+++ b/examples/hydra/daemon.toml
@@ -3,21 +3,6 @@ type = "Hydra"
 hydra_socket_url = "ws://127.0.0.1:4001"
 magic = 42
 
-[chain]
-type = "custom"
-magic = 42
-network_id = 1
-byron_epoch_length = 21600
-byron_slot_length = 20
-byron_known_slot = 18
-byron_known_hash = "96f058d2ab8abb3a7726ef7b18bfba4b9003e84819c59b0a9406a63d48ad274a"
-byron_known_time = 1506203091
-shelley_epoch_length = 432000
-shelley_slot_length = 1
-shelley_known_slot = 18
-shelley_known_hash = "96f058d2ab8abb3a7726ef7b18bfba4b9003e84819c59b0a9406a63d48ad274a"
-shelley_known_time = 1596491091
-
 [intersect]
 type = "Origin"
 

--- a/examples/hydra/daemon.toml
+++ b/examples/hydra/daemon.toml
@@ -19,7 +19,7 @@ shelley_known_hash = "96f058d2ab8abb3a7726ef7b18bfba4b9003e84819c59b0a9406a63d48
 shelley_known_time = 1596491091
 
 [intersect]
-type = "Tip"
+type = "Origin"
 
 [sink]
 type = "Stdout"

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -151,7 +151,7 @@ fn intersect_from_config(intersect: &IntersectConfig) -> Point {
             panic!("intersecting tip not currently supported with hydra as source")
         }
         IntersectConfig::Point(slot, hash_str) => {
-            info!("intersecting specific points");
+            info!("intersecting specific point");
             let hash = hex::decode(hash_str).expect("valid hex hash");
             Point::Specific(slot.clone(), hash)
         }
@@ -165,8 +165,6 @@ fn intersect_from_config(intersect: &IntersectConfig) -> Point {
 impl gasket::framework::Worker<Stage> for Worker {
     async fn bootstrap(stage: &Stage) -> Result<Self, WorkerError> {
         debug!("connecting to hydra WebSocket");
-
-
 
         let url = &stage.config.hydra_socket_url;
         let (socket, _) = connect_async(url).await.expect("Can't connect");

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -90,8 +90,6 @@ pub struct Stage {
 
     intersect: IntersectConfig,
 
-    breadcrumbs: Breadcrumbs,
-
     pub output: SourceOutputPort,
 
     #[metric]
@@ -132,8 +130,6 @@ impl Worker {
                 let evt = ChainEvent::Apply(point.clone(), Record::CborTx(tx));
                 stage.output.send(evt.into()).await.or_panic()?;
                 stage.ops_count.inc(1);
-
-                stage.breadcrumbs.track(point.clone());
 
                 stage.chain_tip.set(point.slot_or_default() as i64);
                 stage.current_slot.set(point.slot_or_default() as i64);
@@ -230,7 +226,6 @@ impl Config {
     pub fn bootstrapper(self, ctx: &Context) -> Result<Stage, Error> {
         let stage = Stage {
             config: self,
-            breadcrumbs: ctx.breadcrumbs.clone(),
             intersect: ctx.intersect.clone(),
             output: Default::default(),
             ops_count: Default::default(),

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -88,8 +88,6 @@ type HydraConnection = WebSocketStream<MaybeTlsStream<TcpStream>>;
 pub struct Stage {
     config: Config,
 
-    chain: GenesisValues,
-
     intersect: IntersectConfig,
 
     breadcrumbs: Breadcrumbs,
@@ -233,7 +231,6 @@ impl Config {
         let stage = Stage {
             config: self,
             breadcrumbs: ctx.breadcrumbs.clone(),
-            chain: ctx.chain.clone().into(),
             intersect: ctx.intersect.clone(),
             output: Default::default(),
             ops_count: Default::default(),


### PR DESCRIPTION
This allows us to resume processing from a point specified in the
config.

Tested manually using the following steps:

1. Ensure hydra demo is running
2. `cargo run daemon --config examples/hydra/daemon.toml`
3. Read the `seq` and `head_id` of the last message printed
4. Set the following in `hydra/daemon.toml`:

```
[intersect]
type = "Point"
value = [
  7,
  "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab"
  ]
```

but with `7` and `84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab`
being the actually observed `seq` and `head_id` values.

5. Restart `oura`
6. Observe that `oura` ignores all previously processed messages

**Next**: Ensure we hit the exact intersection point (with matching `head_id`, not just `seq`) until we start
processing messages to ensure we are on the correct chain. 
