### PR TITLE
Make intersection logic more robust

### DIFF
--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -160,7 +160,7 @@ impl Worker {
             WorkerIntersect::SkipUntil(slot, hash) => {
                 let target = Point::Specific(slot.clone(), hash.clone());
                 debug!(
-                    "Skipping message {} before or at intersection {}",
+                    "Skipping message {} before (or at) requested intersection {}",
                     point.slot_or_default(), target.slot_or_default()
                 );
 

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -4,7 +4,7 @@ use tokio_tungstenite::MaybeTlsStream;
 use pallas::network::miniprotocols::Point;
 
 use gasket::framework::*;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use futures_util::StreamExt;
 use tokio_tungstenite::WebSocketStream;
@@ -143,7 +143,41 @@ pub struct Stage {
 
 pub struct Worker {
     socket: HydraConnection,
-    intersect: Point,
+    intersect: WorkerIntersect,
+}
+#[derive(Debug, Clone)]
+/// Worker state for finding the right intersection point
+pub enum WorkerIntersect {
+    SkipUntil(u64, Vec<u8>), // Possibility of Point::Origin is excluded
+    ProcessMessages,
+}
+
+impl WorkerIntersect {
+    /// When passed the point of the next hydra message, this function will return whether or not
+    /// that message should be processed. The `WorkerIntersect` will be mutated to reflect the
+    /// state where the next message has been processed.
+    fn should_process(&mut self, next: Point) -> bool {
+        match self {
+            WorkerIntersect::SkipUntil(slot, hash) => {
+                let p = Point::Specific(slot.clone(), hash.clone());
+                debug!(
+                    "Skipping message {} before or at intersection {}",
+                    next.slot_or_default(), p.slot_or_default()
+                );
+                if p == next {
+                    *self = WorkerIntersect::ProcessMessages;
+                } else if next.slot_or_default() >= p.slot_or_default() {
+                    warn!(
+                        "Skipping message from wrong hydra chain (intersection point hash mismatch) {:?} {:?}",
+                        p, next
+
+                    );
+                }
+               false
+            }
+            WorkerIntersect::ProcessMessages => true,
+        }
+    }
 }
 
 impl Worker {
@@ -176,11 +210,11 @@ impl Worker {
     }
 }
 
-fn intersect_from_config(intersect: &IntersectConfig) -> Point {
+fn intersect_from_config(intersect: &IntersectConfig) -> WorkerIntersect {
     match intersect {
         IntersectConfig::Origin => {
-            info!("intersecting origin");
-            Point::Origin
+            info!("starting from Origin");
+            WorkerIntersect::ProcessMessages
         }
         IntersectConfig::Tip => {
             panic!("intersecting tip not currently supported with hydra as source")
@@ -188,7 +222,7 @@ fn intersect_from_config(intersect: &IntersectConfig) -> Point {
         IntersectConfig::Point(slot, hash_str) => {
             info!("intersecting specific point");
             let hash = hex::decode(hash_str).expect("valid hex hash");
-            Point::Specific(slot.clone(), hash)
+            WorkerIntersect::SkipUntil(slot.clone(), hash)
         }
         IntersectConfig::Breadcrumbs(_) => {
             panic!("intersecting breadcrumbs not currently supported with hydra as source")
@@ -226,19 +260,10 @@ impl gasket::framework::Worker<Stage> for Worker {
                 debug!("Hydra message: {}", text);
                 match serde_json::from_str::<HydraMessage>(text) {
                     Ok(hydra_message) => {
-                        // TODO: search for the intersection point to ensure
-                        // we're on the same chain.
-                        match &self.intersect {
-                            Point::Specific(slot, _hash) if &hydra_message.seq <= slot => {
-                                debug!(
-                                    "Skipping message {} before or at intersection {}",
-                                    hydra_message.seq, slot
-                                );
-                                Ok(())
-                            }
-                            Point::Origin | Point::Specific(_, _) => {
+                        if self.intersect.should_process(hydra_message.pseudo_point()) {
                                 self.process_next(stage, hydra_message).await
-                            }
+                        } else {
+                            Ok(())
                         }
                     }
                     Err(err) => {

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -145,8 +145,9 @@ pub struct Worker {
     socket: HydraConnection,
     intersect: WorkerIntersect,
 }
-#[derive(Debug, Clone)]
+
 /// Worker state for finding the right intersection point
+#[derive(Debug, Clone)]
 pub enum WorkerIntersect {
     SkipUntil(u64, Vec<u8>), // Possibility of Point::Origin is excluded
     ProcessMessages,

--- a/src/sources/hydra.rs
+++ b/src/sources/hydra.rs
@@ -152,36 +152,33 @@ pub enum WorkerIntersect {
     ProcessMessages,
 }
 
-impl WorkerIntersect {
-    /// When passed the point of the next hydra message, this function will return whether or not
-    /// that message should be processed. The `WorkerIntersect` will be mutated to reflect the
-    /// state where the next message has been processed.
-    fn should_process(&mut self, next: Point) -> bool {
-        match self {
+impl Worker {
+    async fn process(&mut self, stage: &mut Stage, msg: HydraMessage) -> Result<(), WorkerError> {
+        let point = msg.pseudo_point();
+        match &self.intersect {
             WorkerIntersect::SkipUntil(slot, hash) => {
-                let p = Point::Specific(slot.clone(), hash.clone());
+                let target = Point::Specific(slot.clone(), hash.clone());
                 debug!(
                     "Skipping message {} before or at intersection {}",
-                    next.slot_or_default(), p.slot_or_default()
+                    point.slot_or_default(), target.slot_or_default()
                 );
-                if p == next {
-                    *self = WorkerIntersect::ProcessMessages;
-                } else if next.slot_or_default() >= p.slot_or_default() {
+
+                if target == point {
+                    self.intersect = WorkerIntersect::ProcessMessages;
+                } else if point.slot_or_default() >= target.slot_or_default() {
                     warn!(
                         "Skipping message from wrong hydra chain (intersection point hash mismatch) {:?} {:?}",
-                        p, next
-
+                        target, point
                     );
                 }
-               false
+                Ok(())
             }
-            WorkerIntersect::ProcessMessages => true,
+            WorkerIntersect::ProcessMessages => self.process_message(stage, msg).await,
         }
     }
-}
 
-impl Worker {
-    async fn process_next(
+    /// Helper only to be called by `process`
+    async fn process_message(
         &mut self,
         stage: &mut Stage,
         next: HydraMessage,
@@ -260,11 +257,7 @@ impl gasket::framework::Worker<Stage> for Worker {
                 debug!("Hydra message: {}", text);
                 match serde_json::from_str::<HydraMessage>(text) {
                     Ok(hydra_message) => {
-                        if self.intersect.should_process(hydra_message.pseudo_point()) {
-                                self.process_next(stage, hydra_message).await
-                        } else {
-                            Ok(())
-                        }
+                        self.process(stage, hydra_message).await
                     }
                     Err(err) => {
                         error!("Failed to parse Hydra message: {}", err);

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -462,14 +462,14 @@ fn scenario_2() -> TestResult {
 }
 
 #[test]
-fn hydra_oura_stdout_scenario_1() -> TestResult {
-    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt")?;
+fn hydra_oura_stdout_scenario_1() {
+    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
     hydra_oura_stdout_test(scenario, "golden_1".to_string())
 }
 
 #[test]
-fn hydra_oura_stdout_scenario_2() -> TestResult {
-    let scenario = fs::read_to_string("tests/hydra/scenario_2.txt")?;
+fn hydra_oura_stdout_scenario_2() {
+    let scenario = fs::read_to_string("tests/hydra/scenario_2.txt").unwrap();
     hydra_oura_stdout_test(scenario, "golden_2".to_string())
 }
 
@@ -480,7 +480,7 @@ fn hydra_restore_from_intersection_success() {
         6,
         "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab".to_string()
     );
-    let events = events(scenario, intersect);
+    let events = oura_events_from_mock_chain(scenario, intersect);
 
     assert_ne!(events.len(), 0);
     assert_eq!(events[0].point, json!({"slot": 7, "hash": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab"}));
@@ -490,7 +490,6 @@ fn hydra_restore_from_intersection_success() {
         }
     }
 }
-
 #[test]
 fn hydra_restore_from_intersection_failure() {
     let scenario= fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
@@ -498,10 +497,9 @@ fn hydra_restore_from_intersection_failure() {
         6,
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string()
     );
-    let events = events(scenario, bad_intersect);
+    let events = oura_events_from_mock_chain(scenario, bad_intersect);
     assert_eq!(events, vec![]);
 }
-
 
 /// Wraps the json format of oura::framework::ChainEvent::Apply with just enough
 /// structure to test point equality without having to implement the full json
@@ -512,13 +510,13 @@ struct JsonApplyChainEvent {
     record: Value,
 }
 
-fn events(scenario: String, intersect: IntersectConfig) -> Vec<JsonApplyChainEvent> {
+fn oura_output_from_mock_chain(scenario: String, intersect: IntersectConfig) -> String {
     let rt = Runtime::new().unwrap();
     rt.block_on(async move {
         let port: u16 = random_free_port().unwrap();
         let addr = format!("127.0.0.1:{}", port);
-        let server = TcpListener::bind(&addr).await?;
-        let output_file = NamedTempFile::new()?;
+        let server = TcpListener::bind(&addr).await.unwrap();
+        let output_file = NamedTempFile::new().unwrap();
         let mut config = test_config(&output_file, &addr);
         config.intersect = intersect;
 
@@ -528,49 +526,29 @@ fn events(scenario: String, intersect: IntersectConfig) -> Vec<JsonApplyChainEve
         let _ = mock_hydra_node(server, scenario).await;
 
         // After the connection is established, give oura time to process
-        // the chain data and write the output to disk.
+        // the chain data before we read it.
         time::sleep(Duration::from_secs(3)).await;
-
-        let emitted_jsons: Vec<JsonApplyChainEvent> = fs::read_to_string(&output_file)?
-            .lines()
-            .map(|line| serde_json::from_str(line).expect("Invalid JSON line"))
-            .collect();
-
-        Ok::<Vec<JsonApplyChainEvent>, anyhow::Error>(emitted_jsons)
+        fs::read_to_string(&output_file).unwrap()
     })
-    .unwrap()
+}
+
+fn oura_events_from_mock_chain(scenario: String, intersect: IntersectConfig) -> Vec<JsonApplyChainEvent> {
+    oura_output_from_mock_chain(scenario, intersect)
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("Invalid JSON line"))
+        .collect()
 }
 
 // Run:
 // cargo test hydra_oura -- --nocapture
 // in order to see println
-fn hydra_oura_stdout_test(mock_data: String, golden_name: String) -> TestResult {
-
+fn hydra_oura_stdout_test(mock_data: String, golden_name: String) {
     let mut mint = Mint::new("tests/hydra");
     let mut golden = mint.new_goldenfile(golden_name.clone()).unwrap();
 
-    let rt = Runtime::new().unwrap();
-    let _ = rt.block_on(async move {
-        let port: u16 = random_free_port().unwrap();
-        let addr= format!("127.0.0.1:{}", port);
-        let server = TcpListener::bind(&addr).await?;
-        let output_file = NamedTempFile::new()?;
-        let config = test_config(&output_file, &addr);
+    let output = oura_output_from_mock_chain(mock_data, IntersectConfig::Origin);
 
-        println!("WebSocket server starting on ws://{}", addr);
-
-        let _ = tokio::spawn(async move { run_oura(config) });
-        let _ = mock_hydra_node(server, mock_data).await;
-
-        // After the connection is established, give oura time to process
-        // the chain data and write the output to disk.
-        time::sleep(Duration::from_secs(3)).await;
-        let emitted_jsons= fs::read_to_string(output_file)?;
-        golden.write_all(emitted_jsons.as_bytes()).unwrap();
-        println!("test done, will exit");
-        Ok::<(), std::io::Error>(())
-    });
-    Ok(())
+    golden.write_all(output.as_bytes()).unwrap();
 }
 
 /// Will await the first connection, and then return while handling it in the

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -488,9 +488,44 @@ fn hydra_restore_from_intersection_success() {
         }
     }
 }
+
+#[test]
+fn hydra_restore_from_intersection_tip() {
+    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
+    let intersect = IntersectConfig::Point(
+        11,
+        "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab".to_string()
+    );
+    let events = oura_events_from_mock_chain(scenario, intersect);
+    assert_eq!(events, vec![]);
+}
+
+#[test]
+fn hydra_restore_from_intersection_point_with_dummy_hash_and_shared_slot_1() {
+    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
+    let intersect = IntersectConfig::Point(
+        2,
+        "0000000000000000000000000000000000000000000000000000000000000000".to_string()
+    );
+    let events = oura_events_from_mock_chain(scenario, intersect);
+    // It appears the Greetings and HeadIsInitializing messages share the same seq / slot.
+    assert_eq!(events[0].point, json!({"slot": 2, "hash": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab"}))
+}
+
+#[test]
+fn hydra_restore_from_intersection_point_with_shared_slot_2() {
+    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
+    let intersect = IntersectConfig::Point(
+        2,
+        "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab".to_string()
+    );
+    let events = oura_events_from_mock_chain(scenario, intersect);
+    assert_eq!(events[0].point, json!({"slot": 3, "hash": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab"}))
+}
+
 #[test]
 fn hydra_restore_from_intersection_failure() {
-    let scenario= fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
+    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
     let bad_intersect= IntersectConfig::Point(
         6,
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string()

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
-use oura::framework::IntersectConfig;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::mpsc;
 use std::time::Duration;
 
+use serde::Deserialize;
+use oura::framework::IntersectConfig;
 use anyhow::Result;
 use futures_util::SinkExt;
 use oura::sources::hydra::{HydraMessage, HydraMessagePayload};

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -463,14 +463,12 @@ fn scenario_2() -> TestResult {
 
 #[test]
 fn hydra_oura_stdout_scenario_1() {
-    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
-    hydra_oura_stdout_test(scenario, "golden_1".to_string())
+    hydra_oura_stdout_test("scenario_1.txt".to_string(), "golden_1".to_string())
 }
 
 #[test]
 fn hydra_oura_stdout_scenario_2() {
-    let scenario = fs::read_to_string("tests/hydra/scenario_2.txt").unwrap();
-    hydra_oura_stdout_test(scenario, "golden_2".to_string())
+    hydra_oura_stdout_test("scenario_2.txt".to_string(), "golden_2".to_string())
 }
 
 #[test]
@@ -542,11 +540,12 @@ fn oura_events_from_mock_chain(scenario: String, intersect: IntersectConfig) -> 
 // Run:
 // cargo test hydra_oura -- --nocapture
 // in order to see println
-fn hydra_oura_stdout_test(mock_data: String, golden_name: String) {
+fn hydra_oura_stdout_test(scenario_name: String, golden_name: String) {
     let mut mint = Mint::new("tests/hydra");
     let mut golden = mint.new_goldenfile(golden_name.clone()).unwrap();
 
-    let output = oura_output_from_mock_chain(mock_data, IntersectConfig::Origin);
+    let scenario = fs::read_to_string(format!("tests/hydra/{}", scenario_name)).unwrap();
+    let output = oura_output_from_mock_chain(scenario, IntersectConfig::Origin);
 
     golden.write_all(output.as_bytes()).unwrap();
 }

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -461,18 +461,20 @@ fn scenario_2() -> TestResult {
 
 #[test]
 fn hydra_oura_stdout_scenario_1() -> TestResult {
-    hydra_oura_stdout_test("tests/hydra/scenario_1.txt".to_string(), "golden_1".to_string())
+    let scenario = fs::read_to_string("tests/hydra/scenario_1.txt")?;
+    hydra_oura_stdout_test(scenario, "golden_1".to_string())
 }
 
 #[test]
 fn hydra_oura_stdout_scenario_2() -> TestResult {
-    hydra_oura_stdout_test("tests/hydra/scenario_2.txt".to_string(), "golden_2".to_string())
+    let scenario = fs::read_to_string("tests/hydra/scenario_2.txt")?;
+    hydra_oura_stdout_test(scenario, "golden_2".to_string())
 }
 
 // Run:
 // cargo test hydra_oura -- --nocapture
 // in order to see println
-fn hydra_oura_stdout_test(scenario_file: String, golden_name: String) -> TestResult {
+fn hydra_oura_stdout_test(mock_data: String, golden_name: String) -> TestResult {
 
     let mut mint = Mint::new("tests/hydra");
     let mut golden = mint.new_goldenfile(golden_name.clone()).unwrap();
@@ -488,7 +490,7 @@ fn hydra_oura_stdout_test(scenario_file: String, golden_name: String) -> TestRes
         println!("WebSocket server starting on ws://{}", addr);
 
         let _ = tokio::spawn(async move { run_oura(config) });
-        let _ = mock_hydra_node(server, scenario_file).await;
+        let _ = mock_hydra_node(server, mock_data).await;
 
         // After the connection is established, give oura time to process
         // the chain data and write the output to disk.
@@ -503,19 +505,17 @@ fn hydra_oura_stdout_test(scenario_file: String, golden_name: String) -> TestRes
 
 /// Will await the first connection, and then return while handling it in the
 /// background.
-async fn mock_hydra_node(server: TcpListener, file: String) {
+async fn mock_hydra_node(server: TcpListener, mock_data: String) {
     async fn handle_connection(
         stream: tokio::net::TcpStream,
-        file: String,
+        mock_data: String,
         tx: mpsc::Sender<usize>,
     ) -> Result<()> {
         let mut ws_stream = accept_async(stream).await?;
         println!("WebSocket server oura connection established");
 
-        let to_send = fs::read_to_string(file)?;
-
         let mut lines = 0;
-        for line in to_send.lines() {
+        for line in mock_data.lines() {
             ws_stream.send(Message::Text(line.to_string())).await?;
             lines += 1;
         }
@@ -525,7 +525,7 @@ async fn mock_hydra_node(server: TcpListener, file: String) {
 
     let (tx, _rx) = mpsc::channel();
     let (stream, _) = server.accept().await.unwrap();
-    let _ = tokio::spawn(handle_connection(stream, file, tx));
+    let _ = tokio::spawn(handle_connection(stream, mock_data , tx));
 }
 
 

--- a/tests/hydra.rs
+++ b/tests/hydra.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+use oura::framework::IntersectConfig;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::mpsc;
@@ -7,7 +9,7 @@ use anyhow::Result;
 use futures_util::SinkExt;
 use oura::sources::hydra::{HydraMessage, HydraMessagePayload};
 use oura::sinks::Config::FileRotate;
-use serde_json::json;
+use serde_json::{json, Value};
 use tokio::net::TcpListener;
 use oura::sources::Config::Hydra;
 use oura::daemon::{run_daemon, ConfigRoot};
@@ -469,6 +471,74 @@ fn hydra_oura_stdout_scenario_1() -> TestResult {
 fn hydra_oura_stdout_scenario_2() -> TestResult {
     let scenario = fs::read_to_string("tests/hydra/scenario_2.txt")?;
     hydra_oura_stdout_test(scenario, "golden_2".to_string())
+}
+
+#[test]
+fn hydra_restore_from_intersection_success() {
+    let scenario= fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
+    let intersect = IntersectConfig::Point(
+        6,
+        "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab".to_string()
+    );
+    let events = events(scenario, intersect);
+
+    assert_ne!(events.len(), 0);
+    assert_eq!(events[0].point, json!({"slot": 7, "hash": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab"}));
+    for e in events {
+        if e.point == json!({"slot": 6, "hash": "84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab"}) {
+            panic!("only events /after/ the intersection should be emitted");
+        }
+    }
+}
+
+#[test]
+fn hydra_restore_from_intersection_failure() {
+    let scenario= fs::read_to_string("tests/hydra/scenario_1.txt").unwrap();
+    let bad_intersect= IntersectConfig::Point(
+        6,
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string()
+    );
+    let events = events(scenario, bad_intersect);
+    assert_eq!(events, vec![]);
+}
+
+
+/// Wraps the json format of oura::framework::ChainEvent::Apply with just enough
+/// structure to test point equality without having to implement the full json
+/// deserializers.
+#[derive(Debug, Deserialize, PartialEq)]
+struct JsonApplyChainEvent {
+    point: Value,
+    record: Value,
+}
+
+fn events(scenario: String, intersect: IntersectConfig) -> Vec<JsonApplyChainEvent> {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async move {
+        let port: u16 = random_free_port().unwrap();
+        let addr = format!("127.0.0.1:{}", port);
+        let server = TcpListener::bind(&addr).await?;
+        let output_file = NamedTempFile::new()?;
+        let mut config = test_config(&output_file, &addr);
+        config.intersect = intersect;
+
+        println!("WebSocket server starting on ws://{}", addr);
+
+        let _ = tokio::spawn(async move { run_oura(config) });
+        let _ = mock_hydra_node(server, scenario).await;
+
+        // After the connection is established, give oura time to process
+        // the chain data and write the output to disk.
+        time::sleep(Duration::from_secs(3)).await;
+
+        let emitted_jsons: Vec<JsonApplyChainEvent> = fs::read_to_string(&output_file)?
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("Invalid JSON line"))
+            .collect();
+
+        Ok::<Vec<JsonApplyChainEvent>, anyhow::Error>(emitted_jsons)
+    })
+    .unwrap()
 }
 
 // Run:


### PR DESCRIPTION
- If the intersection point the user has specified isn't part of the chain of the hydra node, we will now ignore the messages instead of incorrectly applying them.
    - Caveat: due to `00000...` hashes being used for points of messages without a `head_id`, the guards introduced in this PR can *not in general* guarantee to protect the user from syncing with the wrong chain. Or — it depends on whether the user stores points from the non-tx events which may have dummy hashes.

## Tests

### Basic unit tests

```bash
test hydra_restore_from_intersection_failure ... ok
test hydra_restore_from_intersection_success ... ok
```

### Properties (skipped for now)

Sketch (pseudo-code):
```
// If we provide an invalid intersection point we get no events
events = run_oura_with_mock_hydra_node("scenario1.txt", invalidIntersectPoint)
assert_eq(events, []);

// If we stop processing events at /any point/, and start syncing with that point as intersection point, we will get all events after / be able to have a list of all events in total
events = run_oura_with_mock_hydra_node("scenario1.txt", Point::Origin)
assert_not_empty(events);
for (i, e) in events {
    eventsAfterIntersect = run_oura_with_mock_hydra_node("scenario1.txt", e['point'])
    assert_eq(events[0:i] ++ eventsAfterIntersect, events)
}
```

## Manually tested

### Can restore from intersection

Repeated same manual test from #4 . Example output:

```
2024-11-06T15:34:09.615278Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 0 before or at intersection 3
2024-11-06T15:34:09.615653Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Hydra message: {"peer":"3","seq":1,"tag":"PeerConnected","timestamp":"2024-11-06T12:05:25.468039756Z"}
2024-11-06T15:34:09.615688Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 1 before or at intersection 3
2024-11-06T15:34:09.615742Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Hydra message: {"headId":"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab","parties":[{"vkey":"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb"},{"vkey":"f68e5624f885d521d2f43c3959a0de70496d5464bd3171aba8248f50d5d72b41"},{"vkey":"7abcda7de6d883e7570118c1ccc8ee2e911f2e628a41ab0685ffee15f39bba96"}],"seq":2,"tag":"HeadIsInitializing","timestamp":"2024-11-06T12:05:30.438601425Z"}
2024-11-06T15:34:09.615908Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 2 before or at intersection 3
2024-11-06T15:34:09.615971Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Hydra message: {"headId":"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab","party":{"vkey":"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb"},"seq":3,"tag":"Committed","timestamp":"2024-11-06T12:05:35.017521052Z","utxo":{"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0":{"address":"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":100000000}}}}
2024-11-06T15:34:09.616038Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 3 before or at intersection 3
```

### Invalid intersection point

Oura will not apply the hydra messages, and will instead emit warnings.

```
2024-11-06T15:31:21.382464Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 7 before or at intersection 3
2024-11-06T15:31:21.382484Z  WARN stage{stage="source"}:execute: oura::sources::hydra: Skipping message from wrong hydra chain (intersection point hash mismatch) (3, 84e657e3dd5241caac75b749195f78684023583736cc08b2896290ac) (7, 84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab)
2024-11-06T15:31:21.382615Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Hydra message: {"headId":"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab","seq":8,"signatures":{"multiSignature":["23214a0284de58fee575cd1c4af747a433be0df08f23b5095687608bacc8d9e38376fa93baadae635b514a5cde7ab953cca1a25c2071e2cf52738576d2354607","62f15bd524e2a264def50d3c7e4463340e794e074b8390ddcc6a4a1f12bd3e3f0c21c4bc752f0343174096407e6028b2158d100babe97d7acf5ffa7624bfdd00","a3d9211466ab465bc1fa5a51df756bbc7048e8626801e53d1f1957ff24e7eaa102445c905c54d2c8c7edbe21509f4f043ed71ba382f4f22ede61feb31772b101"]},"snapshot":{"confirmedTransactions":["7e61b7a5008b5e3f5609981f47e265083a54149e519b9f326477b4ca58218a76"],"headId":"84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab","snapshotNumber":1,"utxo":{"7e61b7a5008b5e3f5609981f47e265083a54149e519b9f326477b4ca58218a76#0":{"address":"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":30000000}},"7e61b7a5008b5e3f5609981f47e265083a54149e519b9f326477b4ca58218a76#1":{"address":"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":20000000}},"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0":{"address":"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":100000000}},"f0a39560ea80ccc68e8dffb6a4a077c8927811f06c5d9058d0fa2d1a8d047d20#0":{"address":"addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":25000000}}},"utxoToDecommit":null,"version":0},"tag":"SnapshotConfirmed","timestamp":"2024-11-06T12:18:15.613857501Z"}
2024-11-06T15:31:21.382808Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 8 before or at intersection 3
2024-11-06T15:31:21.382834Z  WARN stage{stage="source"}:execute: oura::sources::hydra: Skipping message from wrong hydra chain (intersection point hash mismatch) (3, 84e657e3dd5241caac75b749195f78684023583736cc08b2896290ac) (8, 84e657e3dd5241caac75b749195f78684023583736cc08b2896290ab)
2024-11-06T15:31:21.382938Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Hydra message: {"headStatus":"Open","hydraNodeVersion":"0.19.0-1ffe7c6b505e3f38b5546ae5e5b97de26bc70425","me":{"vkey":"b37aabd81024c043f53a069c91e51a5b52e4ea399ae17ee1fe3cb9c44db707eb"},"seq":9,"snapshotUtxo":{"7e61b7a5008b5e3f5609981f47e265083a54149e519b9f326477b4ca58218a76#0":{"address":"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":30000000}},"7e61b7a5008b5e3f5609981f47e265083a54149e519b9f326477b4ca58218a76#1":{"address":"addr_test1vp0yug22dtwaxdcjdvaxr74dthlpunc57cm639578gz7algset3fh","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":20000000}},"c9a5fb7ca6f55f07facefccb7c5d824eed00ce18719d28ec4c4a2e4041e85d97#0":{"address":"addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":100000000}},"f0a39560ea80ccc68e8dffb6a4a077c8927811f06c5d9058d0fa2d1a8d047d20#0":{"address":"addr_test1vqx5tu4nzz5cuanvac4t9an4djghrx7hkdvjnnhstqm9kegvm6g6c","datum":null,"datumhash":null,"inlineDatum":null,"referenceScript":null,"value":{"lovelace":25000000}}},"tag":"Greetings","timestamp":"2024-11-06T15:31:21.377834254Z"}
2024-11-06T15:31:21.383035Z DEBUG stage{stage="source"}:execute: oura::sources::hydra: Skipping message 9 before or at intersection 3
2024-11-06T15:31:21.383053Z  WARN stage{stage="source"}:execute: oura::sources::hydra: Skipping message from wrong hydra chain (intersection point hash mismatch) (3, 84e657e3dd5241caac75b749195f78684023583736cc08b2896290ac) (9, 0000000000000000000000000000000000000000000000000000000000000000)
^C
```